### PR TITLE
Cocoapods.support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Xcode
+.DS_Store
+build/*
+*/build/*
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
+profile
+*.moved-aside
+DerivedData
+
+
+# CocoaPods
+Podfile.lock
+Pods/
+
+#Docset/AppleDoc
+Docset/*

--- a/AeroGearGeo.podspec
+++ b/AeroGearGeo.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "AeroGearGeo"
+  s.version      = "0.1.0"
+  s.summary      = "Lightweight geolocation lib."
+  s.homepage     = "https://github.com/sebastienblanc/aerogear-ios-geo"
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = "Red Hat, Inc."
+  s.source       = { :git => 'https://github.com/corinnekrych/aerogear-ios-geo.git',  :branch => 'cocoapods.support'}
+  s.platform     = :ios, 8.0
+  s.source_files = 'UnifiedGeo/*.{swift}'
+end

--- a/UnifiedGeo.xcodeproj/project.pbxproj
+++ b/UnifiedGeo.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		43D6854F1A6C1356002F1258 /* UnifiedGeo.h in Headers */ = {isa = PBXBuildFile; fileRef = 43D6854E1A6C1356002F1258 /* UnifiedGeo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43D685551A6C1356002F1258 /* UnifiedGeo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43D685491A6C1356002F1258 /* UnifiedGeo.framework */; };
-		43D685681A6C15DE002F1258 /* AGClientDeviceInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685651A6C15DE002F1258 /* AGClientDeviceInformation.swift */; };
-		43D685691A6C15DE002F1258 /* AGClientDeviceInformationImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685661A6C15DE002F1258 /* AGClientDeviceInformationImpl.swift */; };
-		43D6856A1A6C15DE002F1258 /* AGDeviceRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685671A6C15DE002F1258 /* AGDeviceRegistration.swift */; };
+		43D685681A6C15DE002F1258 /* ClientDeviceInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685651A6C15DE002F1258 /* ClientDeviceInformation.swift */; };
+		43D685691A6C15DE002F1258 /* ClientDeviceInformationImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685661A6C15DE002F1258 /* ClientDeviceInformationImpl.swift */; };
+		43D6856A1A6C15DE002F1258 /* DeviceRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D685671A6C15DE002F1258 /* DeviceRegistration.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,9 +30,9 @@
 		43D6854E1A6C1356002F1258 /* UnifiedGeo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnifiedGeo.h; sourceTree = "<group>"; };
 		43D685541A6C1356002F1258 /* UnifiedGeoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnifiedGeoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		43D6855A1A6C1356002F1258 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		43D685651A6C15DE002F1258 /* AGClientDeviceInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGClientDeviceInformation.swift; sourceTree = "<group>"; };
-		43D685661A6C15DE002F1258 /* AGClientDeviceInformationImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGClientDeviceInformationImpl.swift; sourceTree = "<group>"; };
-		43D685671A6C15DE002F1258 /* AGDeviceRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AGDeviceRegistration.swift; sourceTree = "<group>"; };
+		43D685651A6C15DE002F1258 /* ClientDeviceInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientDeviceInformation.swift; sourceTree = "<group>"; };
+		43D685661A6C15DE002F1258 /* ClientDeviceInformationImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientDeviceInformationImpl.swift; sourceTree = "<group>"; };
+		43D685671A6C15DE002F1258 /* DeviceRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceRegistration.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,9 +75,9 @@
 		43D6854B1A6C1356002F1258 /* UnifiedGeo */ = {
 			isa = PBXGroup;
 			children = (
-				43D685651A6C15DE002F1258 /* AGClientDeviceInformation.swift */,
-				43D685661A6C15DE002F1258 /* AGClientDeviceInformationImpl.swift */,
-				43D685671A6C15DE002F1258 /* AGDeviceRegistration.swift */,
+				43D685651A6C15DE002F1258 /* ClientDeviceInformation.swift */,
+				43D685661A6C15DE002F1258 /* ClientDeviceInformationImpl.swift */,
+				43D685671A6C15DE002F1258 /* DeviceRegistration.swift */,
 				43D6854E1A6C1356002F1258 /* UnifiedGeo.h */,
 				43D6854C1A6C1356002F1258 /* Supporting Files */,
 			);
@@ -215,9 +215,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43D685681A6C15DE002F1258 /* AGClientDeviceInformation.swift in Sources */,
-				43D685691A6C15DE002F1258 /* AGClientDeviceInformationImpl.swift in Sources */,
-				43D6856A1A6C15DE002F1258 /* AGDeviceRegistration.swift in Sources */,
+				43D685681A6C15DE002F1258 /* ClientDeviceInformation.swift in Sources */,
+				43D685691A6C15DE002F1258 /* ClientDeviceInformationImpl.swift in Sources */,
+				43D6856A1A6C15DE002F1258 /* DeviceRegistration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UnifiedGeo/ClientDeviceInformation.swift
+++ b/UnifiedGeo/ClientDeviceInformation.swift
@@ -20,9 +20,9 @@ import Foundation
 
 public protocol ClientDeviceInformation {    
 
-    var variantID: String? { get set }
+    var apiKey: String? { get set }
     
-    var variantSecret: String? { get set }
+    var apiSecret: String? { get set }
     
     var alias: String? { get set }
     

--- a/UnifiedGeo/ClientDeviceInformation.swift
+++ b/UnifiedGeo/ClientDeviceInformation.swift
@@ -17,39 +17,16 @@
 
 import Foundation
 
-/**
- * Represents the set of allowed device metadata.
- */
-@objc 
-public protocol AGClientDeviceInformation {
-    
-       
-    /**
-     * The ID of the mobile Variant, for which this client will be registered.
-     */
+
+public protocol ClientDeviceInformation {    
+
     var variantID: String? { get set }
     
-    /**
-     * The mobile Variant's secret.
-     */
     var variantSecret: String? { get set }
     
-    /**
-     * Application specific alias to identify users with the system.
-     * E.g. email address or username
-     */
     var alias: String? { get set }
     
-    /**
-    * Device's longitude
-    */
-    var longitude: NSNumber? { get set }
+    var longitude: Double? { get set }
 
-    /**
-    * Device's latitude
-    */
-    var latitude: NSNumber? { get set }
-
-    
-    
+    var latitude: Double? { get set }
 }

--- a/UnifiedGeo/ClientDeviceInformationImpl.swift
+++ b/UnifiedGeo/ClientDeviceInformationImpl.swift
@@ -19,8 +19,8 @@ import Foundation
 
 class ClientDeviceInformationImpl: NSObject, ClientDeviceInformation {
     
-    var variantID: String?
-    var variantSecret: String?
+    var apiKey: String?
+    var apiSecret: String?
     var alias: String?
     var longitude: Double?
     var latitude: Double?

--- a/UnifiedGeo/ClientDeviceInformationImpl.swift
+++ b/UnifiedGeo/ClientDeviceInformationImpl.swift
@@ -17,16 +17,13 @@
 
 import Foundation
 
-/**
- * Internal implementation of the AGClientDeviceInformation protocol
- */
-class AGClientDeviceInformationImpl: NSObject, AGClientDeviceInformation {
+class ClientDeviceInformationImpl: NSObject, ClientDeviceInformation {
     
     var variantID: String?
     var variantSecret: String?
     var alias: String?
-    var longitude: NSNumber?
-    var latitude: NSNumber?
+    var longitude: Double?
+    var latitude: Double?
     
     override init() {
         super.init()        

--- a/UnifiedGeo/DeviceRegistration.swift
+++ b/UnifiedGeo/DeviceRegistration.swift
@@ -17,27 +17,18 @@
 
 import Foundation
 
-/**
- * Utility to register an iOS device with the AeroGear UnifiedPush Server.
- */
-public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
+public class DeviceRegistration: NSObject, NSURLSessionTaskDelegate {
     
-    struct AGDeviceRegistrationError {
-        static let AGGeoErrorDomain = "AGGeoErrorDomain"
-        static let AGNetworkingOperationFailingURLRequestErrorKey = "AGNetworkingOperationFailingURLRequestErrorKey"
-        static let AGNetworkingOperationFailingURLResponseErrorKey = "AGNetworkingOperationFailingURLResponseErrorKey"
+    struct DeviceRegistrationError {
+        static let GeoErrorDomain = "GeoErrorDomain"
+        static let NetworkingOperationFailingURLRequestErrorKey = "NetworkingOperationFailingURLRequestErrorKey"
+        static let NetworkingOperationFailingURLResponseErrorKey = "NetworkingOperationFailingURLResponseErrorKey"
     }
     
     let serverURL: NSURL
     let session: NSURLSession!
     
-    /**
-    * An initializer method to instantiate an AGDeviceRegistration object.
-    *
-    * @param serverURL the URL of the AeroGear Push server.
-    *
-    * @return the AGDeviceRegistration object.
-    */
+
     public init(serverURL: NSURL) {
         self.serverURL = serverURL;
 
@@ -47,28 +38,13 @@ public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
         self.session = NSURLSession(configuration: sessionConfig, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
     }
     
-    /**
-    * Registers your mobile device to the AeroGear Push server so it can
-    * start receiving messages.
-    *
-    * @param clientInfo A block object which passes in an implementation of the AGClientDeviceInformation protocol that
-    * holds configuration metadata that would be posted to the server during the registration process.
-    *
-    * @param success A block object to be executed when the registration operation finishes successfully.
-    * This block has no return value.
-    *
-    * @param failure A block object to be executed when the registration operation finishes unsuccessfully.
-    * This block has no return value and takes one argument: The `NSError` object describing
-    * the error that occurred during the registration process.
-    *
-    */
-    public func registerWithClientInfo(clientInfo: ((config: AGClientDeviceInformation) -> Void)!,
+    public func registerWithClientInfo(clientInfo: ((config: ClientDeviceInformation) -> Void)!,
         success:(() -> Void)!, failure:((NSError) -> Void)!) -> Void {
             
             // can't proceed with no configuration block set
             assert(clientInfo != nil, "configuration block not set")
 
-            let clientInfoObject = AGClientDeviceInformationImpl()
+            let clientInfoObject = ClientDeviceInformationImpl()
         
             clientInfo(config: clientInfoObject)
             
@@ -106,10 +82,10 @@ public class AGDeviceRegistration: NSObject, NSURLSessionTaskDelegate {
 
                     } else { // nope, client request error (e.g. 401 /* Unauthorized */)
                         let userInfo = [NSLocalizedDescriptionKey : NSHTTPURLResponse.localizedStringForStatusCode(httpResp.statusCode),
-                            AGDeviceRegistrationError.AGNetworkingOperationFailingURLRequestErrorKey: request,
-                            AGDeviceRegistrationError.AGNetworkingOperationFailingURLResponseErrorKey: response];
+                            DeviceRegistrationError.NetworkingOperationFailingURLRequestErrorKey: request,
+                            DeviceRegistrationError.NetworkingOperationFailingURLResponseErrorKey: response];
                         
-                        let error = NSError(domain:AGDeviceRegistrationError.AGGeoErrorDomain, code: NSURLErrorBadServerResponse, userInfo: userInfo)
+                        let error = NSError(domain:DeviceRegistrationError.GeoErrorDomain, code: NSURLErrorBadServerResponse, userInfo: userInfo)
 
                         failure(error)
                     }

--- a/UnifiedGeo/DeviceRegistration.swift
+++ b/UnifiedGeo/DeviceRegistration.swift
@@ -48,8 +48,8 @@ public class DeviceRegistration: NSObject, NSURLSessionTaskDelegate {
         
             clientInfo(config: clientInfoObject)
             
-            assert(clientInfoObject.variantID != nil, "'variantID' should be set")
-            assert(clientInfoObject.variantSecret != nil, "'variantSecret' should be set");
+            assert(clientInfoObject.apiKey != nil, "'variantID' should be set")
+            assert(clientInfoObject.apiSecret != nil, "'variantSecret' should be set");
             
             // set up our request
             let request = NSMutableURLRequest(URL: serverURL.URLByAppendingPathComponent("rest/installations"))
@@ -57,7 +57,7 @@ public class DeviceRegistration: NSObject, NSURLSessionTaskDelegate {
             request.HTTPMethod = "POST"
             
             // apply HTTP Basic
-            let basicAuthCredentials: NSData! = "\(clientInfoObject.variantID!):\(clientInfoObject.variantSecret!)".dataUsingEncoding(NSUTF8StringEncoding)
+            let basicAuthCredentials: NSData! = "\(clientInfoObject.apiKey!):\(clientInfoObject.apiSecret!)".dataUsingEncoding(NSUTF8StringEncoding)
             let base64Encoded = basicAuthCredentials.base64EncodedStringWithOptions(NSDataBase64EncodingOptions(0))
             
             request.setValue("Basic \(base64Encoded)", forHTTPHeaderField: "Authorization")

--- a/readme.md
+++ b/readme.md
@@ -4,53 +4,36 @@
 
 A small and handy library written in [Swift](https://developer.apple.com/swift/) that helps to register iOS applications with the AeroGear UnifiedGeo Server.
 
+> This module is beta software, it currently supports Xcode 6.1.1
+
 ## Adding the library to your project 
+To add the library in your project, you can either use [Cocoapods](http://cocoapods.org) or manual install in your project. See the respective sections below for instructions:
 
-TODO
+### Using [Cocoapods](http://cocoapods.org)
+At this time, Cocoapods support for Swift frameworks is supported in a [pre-release](http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/). In your ```Podfile``` add:
 
-### 1. Clone this repository
-
-TODO
-
-### 2. Add `AeroGearPush.xcodeproj` to your application target
-
-TODO
-
-### 4. Start writing your app!
-
-If you run into any problems, please [file an issue](http://issues.jboss.org/browse/AEROGEAR) and/or ask our [user mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-users). You can also join our [dev mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-dev).  
-
-## Example Usage
-
-```swift
-  func locationManager(manager: CLLocationManager!, didUpdateLocations locations: [AnyObject]!) {
-        manager.stopUpdatingLocation()
-        var localValue:CLLocationCoordinate2D = manager.location.coordinate
-        
-        let registration = AGDeviceRegistration(serverURL: NSURL(string: "http://192.168.1.19:8080/unified-geo-server")!)
-        
-        // attemp to register
-        registration.registerWithClientInfo({ (clientInfo: AGClientDeviceInformation!) in
-            // setup configuration
-            clientInfo.alias = "sebI"
-            clientInfo.apiKey = "fa7612b4-329c-417a-80e5-2a48eb44dde4"
-            clientInfo.apiSecret = "8e82aaca-f733-4fbf-9834-16291d9eb726"
-            
-            
-            clientInfo.longitude = localValue.longitude
-            clientInfo.latitude = localValue.latitude
-            },
-            
-            success: {
-                println("UnifiedGeo Server registration succeeded")
-                self.locationManager.stopUpdatingLocation()
-            },
-            failure: {(error: NSError!) in
-                println("failed to register, error: \(error.description)")
-        })
-
-    }
-
-}
+```
+pod 'AeroGearHttpGeo'
 ```
 
+and then:
+
+```bash
+pod install
+```
+
+to install your dependencies
+
+### Manual Installation
+Follow these steps to add the library in your Swift project:
+
+1. Add AeroGearGeo as a [submodule](http://git-scm.com/docs/git-submodule) in your project. Open a terminal and navigate to your project directory. Then enter:
+```bash
+git submodule add https://github.com/aerogear/aerogear-ios-geo.git
+```
+2. Open the `aerogear-ios-geo` folder, and drag the `AeroGearGeo.xcodeproj` into the file navigator in Xcode.
+3. In Xcode select your application target  and under the "Targets" heading section, ensure that the 'iOS  Deployment Target'  matches the application target of AeroGearGeo.framework (Currently set to 8.0).
+5. Select the  "Build Phases"  heading section,  expand the "Target Dependencies" group and add  `AeroGearGeo.framework`.
+7. Click on the `+` button at the top left of the panel and select "New Copy Files Phase". Rename this new phase to "Copy Frameworks", set the "Destination" to "Frameworks", and add `AeroGearGeo.framework`.
+
+If you run into any problems, please [file an issue](http://issues.jboss.org/browse/AEROGEAR) and/or ask our [user mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-users). You can also join our [dev mailing list](https://lists.jboss.org/mailman/listinfo/aerogear-dev). 


### PR DESCRIPTION
@sebastienblanc here is the changes in this PR
- as discussed in mailing list make AeroGearGeo a Swift first lib: remove AG prefix, remove @objc, replace NSNumber by Double?
- add cocopodspec needed to use cocoapod in Helloworld project
